### PR TITLE
city wrapper sizing fix

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -495,6 +495,7 @@ button {
   width: 100%;
   border-bottom: 4px dashed var(--crimson-ua);
   border-radius: 2px;
+  box-sizing: border-box;
 }
 
 .city-anchors {


### PR DESCRIPTION
City wrapper was causing city list to show horizontal overflow. Instead of disabling overflow the size of the wrapper is fixed.